### PR TITLE
Transition to Digitransit API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
+secrets.js
 .lock-waf_linux2_build
 .lock-waf_darwin_build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .lock-waf_linux2_build
+.lock-waf_darwin_build

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ Trebble uses your phone's GPS to locate the nearest bus stops for you. Trebble a
 
 When the stop is chosen, Trebble shows the next departing lines from that stop. By default, Trebble shows the next ten departing lines. From a particular line, the line number and destination is shown. Most importantly, the departure time is shown for each line. Note! Trebble does not use the real time data provided by the Tampere bus API. Because of this it is possible, that the departure times are not always accurate.
 
-# Usage
-This app is licenced under a MIT license. You can use it to do pretty much anything you want. The easiest way to modify and build the code is to download the whole source and open it in Pebble's [CloudPebble](https://cloudpebble.net/) platform. Take note that the icons are downloaded from Freepik (see the README file in the resources/images folder).
-
 # Known issues
 **Times are sometimes incorrect during night time**
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![trebble](https://github.com/ronijaakkola/trebble/blob/master/screenshots/banner.png)
 
 # NOTE
-**As of October 2019, the current version the city of Tampere has depricated Tampere HTTP GET API (http://api.publictransport.tampere.fi/prod/) and suggest using Digitransit APIs (https://digitransit.fi/en/developers/) instead. There is no backwards compatibility and the API did stop working immediately after the annoucement. Currently this application does not work since it did rely on the old HTTP GET API.**
+If you have not heard the news, [Pebble is back](https://repebble.com/)! To celebrate that, this project will be soon be updated back to working order. 
 
 # About
 Trebble is a Pebble smart watch app for finding the next departing busses in Tampere, Finland. It uses GPS location to find your nearest stops and shows the next lines departing from those stops. This source supports all currently available Pebble models, including the latest Pebble 2 which was the last Pebble smart watch released before Fitbit acquired Pebble.

--- a/src/c/l_loading_window.c
+++ b/src/c/l_loading_window.c
@@ -8,7 +8,7 @@ static GBitmap *loadingImage;
 static BitmapLayer *loadingImageLayer;
 static TextLayer *loadingText;
 
-char stopCode[5] = {0};
+char stopCode[20] = {0};
 char stopName[30] = {0};
 static bool line_transfer_started;
 static bool line_got_name;
@@ -19,7 +19,7 @@ struct LineInfo lines[NUM_LINES];
 
 void l_loading_window_show(char *code, char *name)
 {
-	strncpy(stopCode, code, 4);
+	strncpy(stopCode, code, 20);
 	strncpy(stopName, name, 30);
 	window_stack_push(l_loading_window_get_window(), true);
 }

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -29,6 +29,8 @@ void init()
 	
 	// Timeout to show splash screen only for a limited time
 	app_timer_register(1500, open_main_menu, NULL);
+
+	APP_LOG(APP_LOG_LEVEL_DEBUG, "HELLO!");
 }
 
 void deinit() 

--- a/src/c/main.c
+++ b/src/c/main.c
@@ -29,8 +29,6 @@ void init()
 	
 	// Timeout to show splash screen only for a limited time
 	app_timer_register(1500, open_main_menu, NULL);
-
-	APP_LOG(APP_LOG_LEVEL_DEBUG, "HELLO!");
 }
 
 void deinit() 

--- a/src/c/s_loading_window.h
+++ b/src/c/s_loading_window.h
@@ -8,7 +8,7 @@
 #define MAX_OUTBOX_SIZE 64
 
 #define LOADING_BG_COLOR GColorTiffanyBlue
-#define NUM_STOPS 8
+#define NUM_STOPS 10
 
 struct StopInfo {
 	char code[20];

--- a/src/pkjs/app.js
+++ b/src/pkjs/app.js
@@ -187,7 +187,7 @@ stoptimesWithoutPatterns(omitNonPickups: true) {
 }
 
 Pebble.addEventListener("ready", function (e) {
-  console.log("Javascript component ready");
+  console.log("JS: Javascript component ready");
 });
 
 function error(err) {

--- a/src/pkjs/app.js
+++ b/src/pkjs/app.js
@@ -1,4 +1,5 @@
-var apiKey = "";
+const secrets = require('./secrets');
+
 var url = "https://api.digitransit.fi/routing/v2/finland/gtfs/v1";
 
 var options = {
@@ -65,7 +66,7 @@ function getStopsFromLocation(pos) {
   req.open("POST", url, true);
 
   req.setRequestHeader("Content-Type", "application/graphql");
-  req.setRequestHeader("digitransit-subscription-key", apiKey);
+  req.setRequestHeader("digitransit-subscription-key", secrets.API_KEY);
 
   req.onload = function (e) {
     if (req.readyState === 4) {
@@ -76,7 +77,6 @@ function getStopsFromLocation(pos) {
           return;
         }
         var response = JSON.parse(req.responseText);
-        console.log(response);
 
         if (response && response.data && response.data.stopsByRadius) {
           var edges = response.data.stopsByRadius.edges;
@@ -133,7 +133,7 @@ stoptimesWithoutPatterns(omitNonPickups: true) {
 
   // Set the required headers
   req.setRequestHeader("Content-Type", "application/graphql");
-  req.setRequestHeader("digitransit-subscription-key", apiKey);
+  req.setRequestHeader("digitransit-subscription-key", secrets.API_KEY);
 
   req.onload = function (e) {
     if (req.readyState === 4) {
@@ -191,6 +191,13 @@ function error(err) {
   Pebble.sendAppMessage({ noGps: 1 });
 }
 
+var fakePosition = {
+  coords: {
+    latitude: 61.495,
+    longitude: 23.761,
+  },
+};
+
 function convertSecondsToTime(seconds) {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
@@ -205,11 +212,14 @@ function convertSecondsToTime(seconds) {
 Pebble.addEventListener("appmessage", function (e) {
   if (e.payload.stopMessage) {
     console.log("JS: Received stopMessage.");
+    getStopsFromLocation(fakePosition);
+    /*
     navigator.geolocation.getCurrentPosition(
       getStopsFromLocation,
       error,
       options
     );
+	*/
   } else if (e.payload.lineMessage) {
     console.log(
       "JS: Received lineMessage with stopCode: " + e.payload.lineMessage

--- a/src/pkjs/app.js
+++ b/src/pkjs/app.js
@@ -1,12 +1,10 @@
-// TODO: Old HTTP GET API has been depricated. We should start using Digitransit API (https://digitransit.fi/en/developers/)
-
 var apiKey = "";
-var apiPassphrase = "";
+var url = "https://api.digitransit.fi/routing/v2/finland/gtfs/v1";
 
 var options = {
   enableHighAccuracy: true,
   timeout: 5000,
-  maximumAge: 0
+  maximumAge: 0,
 };
 
 // Stop search parameters
@@ -21,147 +19,203 @@ function sendNextItem(items, index) {
   // Build message
   var dict = items[index];
 
-  // Send the message
-  Pebble.sendAppMessage(dict, function() {
-    // Use success callback to increment index
-    index++;
+  Pebble.sendAppMessage(
+    dict,
+    function () {
+      // Use success callback to increment index
+      index++;
 
-    if(index < items.length) {
-      // Send next item
-      sendNextItem(items, index);
-    } else {
-			Pebble.sendAppMessage({ messageEnd: 1 });
+      if (index < items.length) {
+        sendNextItem(items, index);
+      } else {
+        Pebble.sendAppMessage({ messageEnd: 1 });
+      }
+    },
+    function () {
+      console.log("JS: Item transmission failed at index: " + index);
     }
-  }, function() {
-		console.log('JS: Item transmission failed at index: ' + index);
-  });
+  );
 }
 
 function sendList(items) {
-	var index = 0;
+  var index = 0;
   sendNextItem(items, index);
 }
 
-function parseStops(json) 
-{
-	var stops = [];
-	for (var i = 0; i < json.length; ++i) {
-		var stop = json[i];
-		stops.push({
-			'stopMessage': 1,
-			'stopCode': stop.code,
-			'stopName': stop.name,
-			'stopDist': stop.dist
-		});
-	}
-	return stops;
-}
+function getStopsFromLocation(pos) {
+  var crd = pos.coords;
 
-function parseLines(json) 
-{
-	var lines = [];
-	for (var i = 0; i < json.length; ++i) {
-		var line = json[i];
-		var time = line.time.substring(0,2) + ':' + line.time.substring(2);
-		var dir = line.name1.split(" - ")[1];
-		lines.push({
-			'lineMessage': 1,
-			'lineCode': line.code,
-			'lineTime': time,
-			'lineDir': dir
-		});
-	}
-	return lines;
-}
-
-// TODO: Old HTTP GET API has been depricated. We should start using Digitransit API (https://digitransit.fi/en/developers/)
-// NOTE: Data format Digitransit uses is vastly different from the old APIs.
-function getStopsFromLocation(pos) 
-{
-  var response;
-	var crd = pos.coords;
-	// NOTE: Depricated API
-	var url = "http://api.publictransport.tampere.fi/prod/?request=stops_area&user=" + apiKey + "&pass=" + apiPassphrase + "&epsg_in=wgs84&center_coordinate=" + crd.longitude + "," + crd.latitude + "&limit=" + stopsLimit + "&diameter=" + stopSearchDiameter;
-	
-  var req = new XMLHttpRequest();
-  req.open('GET', url, true);
-  req.onload = function(e) {
-  	if (req.readyState == 4) {
-    	if (req.status == 200) {
-				if (req.responseText === "") {
-					console.log("JS: Stops request returned no stops.");
-					Pebble.sendAppMessage({ stopNoFound: 1 });
-					return;
-				}
-        response = JSON.parse(req.responseText);
-        if (response) {
-					sendList(parseStops(response));
-				}
-    	}
-    	else {
-				console.log("JS: Error in getting stops from location.");
-				Pebble.sendAppMessage({ stopNoFound: 1 });
-    	}
-    }
-  };
-	req.send(null);
-}
-
-// TODO: Old HTTP GET API has been depricated. We should start using Digitransit API (https://digitransit.fi/en/developers/)
-// NOTE: Data format Digitransit uses is vastly different from the old APIs.
-function getDepartingLines(stopCode) 
-{
-	var response;
-	// NOTE: Depricated API
-  	var url = "http://api.publictransport.tampere.fi/prod/?request=stop&user=" + apiKey + "&pass=" + apiPassphrase + "&code=" + stopCode + "&time_limit=" + timeLimit + "&dep_limit=" + depLimit;
-	
-  var req = new XMLHttpRequest();
-  req.open('GET', url, true);
-  req.onload = function(e) {
-  	if (req.readyState == 4) {
-    	if (req.status == 200) {
-				if (req.responseText === "") {
-					console.log("JS: Lines request returned no departing lines.");
-					Pebble.sendAppMessage({ lineNoFound: 1 });
-					return;
-				}
-        response = JSON.parse(req.responseText);
-        if (response) {
-					if (response[0].departures === "") {
-						console.log("JS: Lines request returned no departing lines.");
-						Pebble.sendAppMessage({ lineNoFound: 1 });
-						return;
-					}
-					sendList(parseLines(response[0].departures));
-				}
+  var query = `
+	{
+	stopsByRadius(lat: ${crd.latitude}, lon: ${crd.longitude}, radius: ${stopSearchDiameter}, first: 10) {
+		edges {
+		node {
+			stop {
+			gtfsId
+			name
 			}
-    }
-    else {
-			console.log("JS: Error in getting lines of stop.");
+			distance
+		}
+		}
+	}
+	}
+	`;
+
+  var req = new XMLHttpRequest();
+  req.open("POST", url, true);
+
+  req.setRequestHeader("Content-Type", "application/graphql");
+  req.setRequestHeader("digitransit-subscription-key", apiKey);
+
+  req.onload = function (e) {
+    if (req.readyState === 4) {
+      if (req.status === 200) {
+        if (req.responseText === "") {
+          console.log("JS: Stops request returned no stops.");
+          Pebble.sendAppMessage({ stopNoFound: 1 });
+          return;
+        }
+        var response = JSON.parse(req.responseText);
+        console.log(response);
+
+        if (response && response.data && response.data.stopsByRadius) {
+          var edges = response.data.stopsByRadius.edges;
+
+          var stops = edges.map(function (edge) {
+            return {
+              stopMessage: 1,
+              stopCode: edge.node.stop.gtfsId,
+              stopName: edge.node.stop.name,
+              stopDist: edge.node.distance,
+            };
+          });
+          console.log(stops);
+
+          sendList(stops);
+        } else {
+          console.log("JS: No valid stops data in the GraphQL response.");
+          Pebble.sendAppMessage({ stopNoFound: 1 });
+        }
+      } else {
+        console.log(
+          "JS: Error in getting stops from location. Status: " + req.status
+        );
+        Pebble.sendAppMessage({ stopNoFound: 1 });
+      }
     }
   };
-	req.send(null);
+
+  req.send(query);
 }
 
-Pebble.addEventListener("ready", function(e) {
-	console.log("Javascript component ready");								
+function getDepartingLines(stopCode) {
+
+  var query = `
+{
+stop(id: "${stopCode}") {
+name
+stoptimesWithoutPatterns(omitNonPickups: true) {
+  scheduledDeparture
+  headsign
+  trip {
+	route {
+	  shortName
+	}
+  }
+}
+}
+}
+`;
+
+  // Create a new POST request
+  var req = new XMLHttpRequest();
+  req.open("POST", url, true);
+
+  // Set the required headers
+  req.setRequestHeader("Content-Type", "application/graphql");
+  req.setRequestHeader("digitransit-subscription-key", apiKey);
+
+  req.onload = function (e) {
+    if (req.readyState === 4) {
+      if (req.status === 200) {
+        if (req.responseText === "") {
+          console.log("JS: Lines request returned no departing lines.");
+          Pebble.sendAppMessage({ lineNoFound: 1 });
+          return;
+        }
+        var response = JSON.parse(req.responseText);
+
+        if (response && response.data && response.data.stop) {
+          var stop = response.data.stop;
+          var stopName = stop.name;
+          var stoptimes = stop.stoptimesWithoutPatterns;
+
+          if (!stoptimes || stoptimes.length === 0) {
+            console.log("JS: No departing lines found for this stop.");
+            Pebble.sendAppMessage({ lineNoFound: 1 });
+            return;
+          }
+
+          var lines = stoptimes.map(function (line) {
+            return {
+              lineMessage: 1,
+              lineCode: line.trip.route.shortName,
+              lineTime: convertSecondsToTime(line.scheduledDeparture),
+              lineDir: line.headsign,
+            };
+          });
+
+          sendList(lines);
+        } else {
+          console.log("JS: No valid line data in the GraphQL response.");
+          Pebble.sendAppMessage({ lineNoFound: 1 });
+        }
+      } else {
+        console.log(
+          "JS: Error in getting lines for stop. Status: " + req.status
+        );
+        Pebble.sendAppMessage({ lineNoFound: 1 });
+      }
+    }
+  };
+
+  req.send(query);
+}
+
+Pebble.addEventListener("ready", function (e) {
+  console.log("Javascript component ready");
 });
 
 function error(err) {
-	console.warn('JS: GPS error (' + err.code + '): ' + err.message);
-	Pebble.sendAppMessage({ noGps: 1 });
+  console.warn("JS: GPS error (" + err.code + "): " + err.message);
+  Pebble.sendAppMessage({ noGps: 1 });
 }
 
-Pebble.addEventListener("appmessage", function(e) {
-	if (e.payload.stopMessage) {
-		console.log("JS: Received stopMessage.");
-		navigator.geolocation.getCurrentPosition(getStopsFromLocation, error, options);
-	}
-	else if (e.payload.lineMessage) {
-		console.log("JS: Received lineMessage with stopCode: " + e.payload.lineMessage);
-		getDepartingLines(e.payload.lineMessage);
-	}
-	else {
-		console.log("JS: Received unknown message from Pebble!");
-	}
+function convertSecondsToTime(seconds) {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+
+  // Pad hours and minutes with leading zeros if needed
+  const paddedHours = hours.toString().padStart(2, "0");
+  const paddedMinutes = minutes.toString().padStart(2, "0");
+
+  return `${paddedHours}:${paddedMinutes}`;
+}
+
+Pebble.addEventListener("appmessage", function (e) {
+  if (e.payload.stopMessage) {
+    console.log("JS: Received stopMessage.");
+    navigator.geolocation.getCurrentPosition(
+      getStopsFromLocation,
+      error,
+      options
+    );
+  } else if (e.payload.lineMessage) {
+    console.log(
+      "JS: Received lineMessage with stopCode: " + e.payload.lineMessage
+    );
+    getDepartingLines(e.payload.lineMessage);
+  } else {
+    console.log("JS: Received unknown message from Pebble!");
+  }
 });


### PR DESCRIPTION
Change the PKJS to use Digitransit API since the Tampere HTTP GET API has been discontinued.