### PR TITLE
feat: per-city bus stop colors for all Digitransit cities

### DIFF
--- a/src/c/region.c
+++ b/src/c/region.c
@@ -12,10 +12,45 @@ static bool feed_is(const char *gtfs_id, const char *feed)
 	return strncmp(gtfs_id, feed, n) == 0 && gtfs_id[n] == ':';
 }
 
+// Per-city bus colors, each operator's own brand color (digitransit-ui
+// colors.primary) snapped to the Pebble 64-color palette. A few are deliberate
+// overrides rather than the nearest snap: Hameenlinna's #F76013 reads as red on the
+// watch, and Raasepori's olive #5B7B32 snaps to gray so it is nudged to a green.
+// Kouvola is intentionally absent: its brand is black, which reads as no theme, so it
+// falls through to the default blue below. The key is the gtfsId feed prefix, the same
+// value feed_is() matches on. Cities sharing a color (e.g. Helsinki/Tampere/Lahti) is
+// fine: two cities never appear on screen together.
+static const struct {
+	const char *feed;
+	GColor color;
+} bus_colors[] = {
+	{ "HSL", { .argb = GColorCobaltBlueARGB8 } },        // Helsinki
+	{ "tampere", { .argb = GColorCobaltBlueARGB8 } },    // Tampere (Nysse)
+	{ "Hameenlinna", { .argb = GColorRedARGB8 } },       // override: brand #F76013
+	{ "Joensuu", { .argb = GColorLibertyARGB8 } },
+	{ "LINKKI", { .argb = GColorMayGreenARGB8 } },       // Jyvaskyla
+	{ "Kotka", { .argb = GColorVividCeruleanARGB8 } },
+	{ "Kuopio", { .argb = GColorTiffanyBlueARGB8 } },
+	{ "Lahti", { .argb = GColorCobaltBlueARGB8 } },
+	{ "Lappeenranta", { .argb = GColorBrilliantRoseARGB8 } },
+	{ "Mikkeli", { .argb = GColorPictonBlueARGB8 } },
+	{ "OULU", { .argb = GColorFollyARGB8 } },
+	{ "Pori", { .argb = GColorOxfordBlueARGB8 } },
+	{ "Raasepori", { .argb = GColorArmyGreenARGB8 } },   // override: olive -> keep green
+	{ "Rovaniemi", { .argb = GColorMayGreenARGB8 } },
+	{ "FOLI", { .argb = GColorChromeYellowARGB8 } },     // Turku (Foli)
+	{ "Vaasa", { .argb = GColorDukeBlueARGB8 } },
+};
+
 GColor region_mode_color(const char *gtfs_id, char type)
 {
 	if (type == 'B') {
-		// Buses are blue across all regions.
+		// Each city's own bus brand color; un-themed feeds fall back to blue.
+		for (unsigned i = 0; i < ARRAY_LENGTH(bus_colors); i++) {
+			if (feed_is(gtfs_id, bus_colors[i].feed)) {
+				return bus_colors[i].color;
+			}
+		}
 		return GColorCobaltBlue;
 	}
 	if (type == 'T') {

--- a/src/c/region.h
+++ b/src/c/region.h
@@ -2,8 +2,9 @@
 #include <pebble.h>
 
 // Returns the badge/bar color for a transit mode at a given stop, keyed off the
-// stop's Digitransit feed (the prefix of its gtfsId, e.g. "HSL:..."). Buses are
-// blue everywhere; trams are green in Helsinki (HSL) and red elsewhere. Unknown
+// stop's Digitransit feed (the prefix of its gtfsId, e.g. "HSL:..."). Buses use each
+// city's own brand color (see the bus_colors table in region.c), falling back to blue
+// for un-themed feeds; trams are green in Helsinki (HSL) and red elsewhere. Unknown
 // modes get a neutral black. The returned value is the color-watch color; callers
 // wrap it in COLOR_FALLBACK where a black-and-white fallback is wanted.
 GColor region_mode_color(const char *gtfs_id, char type);

--- a/src/pkjs/app.js
+++ b/src/pkjs/app.js
@@ -38,6 +38,21 @@ function isEmulator() {
 var feedToCity = {
   HSL: "Helsinki",
   tampere: "Tampere",
+  Hameenlinna: "Hameenlinna",
+  Joensuu: "Joensuu",
+  LINKKI: "Jyvaskyla",
+  Kotka: "Kotka",
+  Kouvola: "Kouvola",
+  Kuopio: "Kuopio",
+  Lahti: "Lahti",
+  Lappeenranta: "Lappeenranta",
+  Mikkeli: "Mikkeli",
+  OULU: "Oulu",
+  Pori: "Pori",
+  Raasepori: "Raasepori",
+  Rovaniemi: "Rovaniemi",
+  FOLI: "Turku",
+  Vaasa: "Vaasa",
 };
 
 function cityFromGtfsId(gtfsId) {


### PR DESCRIPTION
## Summary
Bus stop badges and departure bars now use each transit operator's own brand color instead of a single shared blue. Previously only Helsinki and Tampere were themed (and only their trams varied); every other city rendered the same generic blue bus badge.

Colors are sourced from each city's `digitransit-ui` `colors.primary` (the operator's own brand color), snapped to the Pebble 64-color palette and validated with a perceptual (redmean) color-distance pass.

## Changes
- **`src/c/region.c`** — adds a static `bus_colors[]` table (gtfsId feed prefix → `GColor`) and changes the bus branch from a hardcoded blue to a table lookup, falling back to `GColorCobaltBlue` for un-themed feeds. Trams unchanged.
- **`src/c/region.h`** — doc comment updated.
- **`src/pkjs/app.js`** — `feedToCity` extended so the menu header resolves a label for all 16 themed cities.

## Notable decisions
- **Hämeenlinna** → `GColorRed` and **Raasepori** → `GColorArmyGreen`: deliberate overrides where the nearest snap read wrong (orange-that-looks-red; olive that snapped to gray).
- **Kouvola** intentionally omitted — its brand is literally black, which reads as no theme, so it falls back to the default blue.
- Color collisions between distant cities are accepted by design (two cities never appear on screen together).

## Verification
- Builds across all five platforms (aplite, basalt, chalk, diorite, emery).
- Drove the basalt emulator for the legibility-risk cities (Mikkeli, Turku, Jyväskylä, Rovaniemi); feeds resolved to real local stops and white-on-color text was legible. Turku (`GColorChromeYellow`) is the lowest-contrast but readable — a potential follow-up is adaptive badge text color.

🤖 Generated with [Claude Code](https://claude.com/claude-code)